### PR TITLE
Add PR preview deployment via GitHub Actions

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,138 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            ~/.rustup
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Library caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache
+          key: ${{ runner.os }}-library-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-library-
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup just
+        uses: extractions/setup-just@v3
+
+      - name: Build webapp
+        run: just build_www
+
+      - name: Deploy to GitHub Pages (PR Preview)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./www/dist
+          destination_dir: pr-preview/pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Comment PR with preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://${{ github.repository_owner }}.github.io/htmf/pr-preview/pr-${prNumber}/`;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('PR Preview')
+            );
+
+            const commentBody = `## 🚀 PR Preview
+
+            Your preview is ready! View the changes at:
+
+            **${previewUrl}**
+
+            This preview will be updated automatically when you push new commits to this PR.
+
+            ---
+            <sub>Built with commit ${context.sha.substring(0, 7)}</sub>`;
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        run: |
+          rm -rf pr-preview/pr-${{ github.event.number }}
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Remove preview for PR #${{ github.event.number }}" || echo "No changes to commit"
+          git push origin gh-pages || echo "No changes to push"
+
+      - name: Comment PR about cleanup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: '## 🧹 Preview Cleanup\n\nThe preview for this PR has been removed.',
+            });

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hey, that's my fish!
 
 [![WWW build](https://github.com/jthemphill/htmf/actions/workflows/www-build.yml/badge.svg)](https://github.com/jthemphill/htmf/actions/workflows/www-build.yml)
+[![PR Preview](https://github.com/jthemphill/htmf/actions/workflows/pr-preview.yml/badge.svg)](https://github.com/jthemphill/htmf/actions/workflows/pr-preview.yml)
 
 ## Simple webapp version of a deceptively simple children's game
 
@@ -26,3 +27,11 @@ To run all tests:
 ```sh
 just test
 ```
+
+## Pull Request Previews
+
+When you open a pull request, a preview of your changes will be automatically deployed to GitHub Pages. The preview URL will be posted as a comment on your PR, allowing reviewers to test your changes before merging.
+
+Preview URLs follow the format: `https://jthemphill.github.io/htmf/pr-preview/pr-{number}/`
+
+The preview will be automatically updated when you push new commits, and cleaned up when the PR is closed.


### PR DESCRIPTION
- Add pr-preview.yml workflow that builds and deploys PR previews to GitHub Pages
- Previews are deployed to pr-preview/pr-{number}/ subdirectories
- Workflow posts a comment on PRs with the preview URL
- Automatic cleanup when PR is closed
- Update README with PR preview documentation and workflow badge